### PR TITLE
Optymalizacja algorytmów kompresji

### DIFF
--- a/compression.h
+++ b/compression.h
@@ -31,7 +31,7 @@ public:
     void BWT_make2();   // Burrows-Wheeler transform (divsufsort)
     void BWT_reverse2();
 
-    void MTF_make();    // move-to-front
+    void MTF_make();    // move-to-front (savage)
     void MTF_reverse();
 
     void RLE_make();    // run-length encoding (interlaced)
@@ -40,7 +40,7 @@ public:
     void RLE_makeV2();  // run-length encoding (separated)
     void RLE_reverseV2();
 
-    void AC_make();     // arithmetic coding (memoryless)
+    void AC_make();     // arithmetic coding (memoryless model)
     void AC_reverse();
 
     void AC2_make();    // arithmetic coding (first-order Markov model)

--- a/cryptography.h
+++ b/cryptography.h
@@ -19,7 +19,7 @@ namespace crypto {
 
     namespace PBKDF2 {
         static const uint32_t saltSize = 16;
-        enum class iteration_count { debug=1000, low=160000, medium=320000, high=720000 };
+        enum class iteration_count { low=160000, medium=320000, high=720000 };
 
         std::string HMAC_SHA256(std::string &pw, uint8_t salt[], uint32_t salt_size,
                                 uint32_t iteration_count, uint32_t dkLen, bool &aborting_var);

--- a/integrity_validation.cpp
+++ b/integrity_validation.cpp
@@ -6,8 +6,6 @@
 #include <filesystem>
 #include <bit>
 #include <cmath>
-#include <sstream>
-
 
 IntegrityValidation::IntegrityValidation()
 : SHA1_num(nullptr), SHA256_num(nullptr), CRC32_num(nullptr) {
@@ -46,8 +44,7 @@ std::string IntegrityValidation::get_SHA1_from_file(const std::string &path_to_f
 
         uint8_t buffer[64];
         uint8_t leftover_buffer[64];
-        uint32_t chunk[80];
-        for (uint32_t i=0; i < 80; ++i) chunk[i] = 0;
+        uint32_t chunk[80] = {};
 
         uint64_t byte_counter = 0;
 
@@ -67,9 +64,16 @@ std::string IntegrityValidation::get_SHA1_from_file(const std::string &path_to_f
 
                     if (64 - read_counter < 8) {
                         leftover = true;
-                        for (uint32_t i = 0; i < 64; ++i) leftover_buffer[i] = 0;
-                        for (int i = 0; i<8; ++i) leftover_buffer[56 + 7-i] = (byte_counter * 8 >> i * 8) & 0xFF;
-                    } else for (int i = 0; i<8 ; ++i) buffer[56 + 7-i] = (byte_counter * 8 >> i * 8) & 0xFF;
+
+                        for (uint32_t i = 0; i < 64; ++i) {
+                            leftover_buffer[i] = 0;
+                        }
+
+                        for (int i = 0; i<8; ++i) {
+                            leftover_buffer[56 + 7 - i] = (byte_counter * 8 >> i * 8) & 0xFF;
+                        }
+
+                    } else for (int i = 0; i<8 ; ++i) buffer[56 + 7 - i] = (byte_counter * 8 >> i * 8) & 0xFF;
                 }
             }
             else {
@@ -87,11 +91,11 @@ std::string IntegrityValidation::get_SHA1_from_file(const std::string &path_to_f
                 }
                 chunk[i] = word;
             }
+
             for (uint8_t id=16; id < 80; id++)
             {
                 chunk[id] =  std::rotl(chunk[id-3] ^ chunk[id-8] ^ chunk[id-14] ^ chunk[id-16], 1);
             }
-
 
             a = h0;
             b = h1;
@@ -134,7 +138,9 @@ std::string IntegrityValidation::get_SHA1_from_file(const std::string &path_to_f
             h2 += c;
             h3 += d;
             h4 += e;
+
         }
+
         target_file.close();
         if (aborting_var) return "";
 
@@ -638,7 +644,6 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
     if (!aborting_var) {
         assert( text != nullptr and text_size != 0 );
 
-
         uint32_t h0 = 0x6A09E667;
         uint32_t h1 = 0xBB67AE85;
         uint32_t h2 = 0x3C6EF372;
@@ -670,8 +675,6 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
                                         0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
 
 
-
-
         uint32_t buffer_size = 64;
         uint8_t buffer[buffer_size];
         uint8_t leftover_buffer[buffer_size];
@@ -682,11 +685,8 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
 
         uint64_t byte_counter = 0;
 
-
-
         bool leftover = false;
 
-        // while ( target_file.good() or leftover )
         uint32_t blocks = ceil((double)text_size / (double)buffer_size);
 
         for (uint32_t current_block = 0; current_block < blocks; ++current_block)
@@ -700,7 +700,6 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
                 }
 
                 else if ((current_block+1) * buffer_size != text_size)
-                    // if (target_file.gcount() < buffer_size)
                 {
                     for (uint32_t i=current_block * buffer_size; i < text_size; ++i)
                         buffer[i - current_block * buffer_size] = text[i];
@@ -725,8 +724,6 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
                     byte_counter += read_counter;
                     blocks++;
 
-
-                    //*
                     leftover = true;
                     for (uint32_t i = 0; i < buffer_size; ++i) leftover_buffer[i] = 0;
                     leftover_buffer[0] = 0x80;
@@ -758,6 +755,7 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
                 chunks[i] = chunks[i - 16] + S0 + chunks[i - 7] + S1;
             }
 
+
             a = h0;
             b = h1;
             c = h2;
@@ -786,6 +784,7 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
                 b = a;
                 a = temp1 + temp2;
             }
+
             h0 += a;
             h1 += b;
             h2 += c;
@@ -796,6 +795,7 @@ std::string IntegrityValidation::get_SHA256_from_text( uint8_t text[], uint64_t 
             h7 += h;
         }
         if (aborting_var) return "";
+
 
         std::stringstream stream;
         stream << std::hex;

--- a/misc/dc3.h
+++ b/misc/dc3.h
@@ -3,23 +3,11 @@
 
 #include <cstdint>
 #include <cmath>
+#include <iomanip>
+#include <iostream>
 
 namespace dc3
 {
-    /*
-    template <class someInt>
-    void print_array(someInt array[], uint64_t size, const std::string& message="", const std::string& sep=", ")
-    {
-        std::cout << message << '\n' << '[';
-        for (uint64_t i=0; i < size; ++i)
-        {
-            std::cout << (uint64_t)array[i];
-            if (i != size-1) std::cout << sep;
-        }
-        std::cout << ']' << std::endl;
-    }//*/
-
-
     inline uint32_t get_B1(uint32_t i) { return 3*i + 1; }
 
     inline uint32_t get_B2(uint32_t i) { return 3*i + 2; }
@@ -81,7 +69,7 @@ namespace dc3
             if (alphabet[i] != 0)
             {
                 alphabet[i] = current_letter;
-                current_letter++;
+                ++current_letter;
             }
         }
         uint32_t max_letter = current_letter;
@@ -101,8 +89,6 @@ namespace dc3
 
         delete[] text;
         delete[] alphabet;
-        // g_alphabet += std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - t0).count();
-
 
         // Calculating indices of every element not divisible by 3 for sorting
         uint32_t B1_offset = count_divisible(1, translated_size-3, 3, 1);
@@ -110,8 +96,6 @@ namespace dc3
         uint32_t B0_size = count_divisible(0, translated_size-3, 3, 0);
 
         auto B12_sorted = new uint32_t[B12_size];
-
-        for (uint32_t i=0; i < B12_size; ++i) B12_sorted[i] = 0;
 
         uint32_t B1_max_index = ceil((double)B12_size/2);
         for (uint32_t i=0; i < B1_max_index; ++i)
@@ -125,8 +109,6 @@ namespace dc3
             B12_sorted[2*i+1] = 3*i+2;
         }
 
-
-
         counting_sort_indices(B12_sorted, translated, B12_size, max_letter, 2);
         counting_sort_indices(B12_sorted, translated, B12_size, max_letter, 1);
         counting_sort_indices(B12_sorted, translated, B12_size, max_letter, 0);
@@ -138,19 +120,35 @@ namespace dc3
 
         rank_array[0] = 1;
 
+        uint32_t previous1 = -1;
+        uint32_t previous2 = -1;
+        uint32_t previous3 = -1;
+
+        uint32_t next1 = -1;
+        uint32_t next2 = -1;
+        uint32_t next3 = -1;
+
         for (uint32_t i=1; i < B12_size; ++i)
         {
-            // looking for repeats within sorted text, they should obviously be next to each other
-            if (not (translated[B12_sorted[i - 1]] == translated[B12_sorted[i]] and translated[B12_sorted[i - 1] + 1] == translated[B12_sorted[i] + 1] and translated[B12_sorted[i - 1] + 2] == translated[B12_sorted[i] + 2]))
-                current_rank++;
-            else
+            // while looking for repeats within sorted text, they should obviously be next to each other
+            next1 = translated[B12_sorted[i]];
+            next2 = translated[B12_sorted[i]+1];
+            next3 = translated[B12_sorted[i]+2];
+
+            if ((previous1 == next1 and previous2 == next2 and previous3 == next3))
+            {
                 repeats = true;
+            }
+            else {
+                ++current_rank;
+                previous1 = next1;
+                previous2 = next2;
+                previous3 = next3;
+            }
             rank_array[i] = current_rank;
         }
 
         auto translation_ranked = new uint32_t[translated_size]();
-
-        for (uint32_t i=size; i < translated_size; ++i) translation_ranked[i] = 0;
 
         for (uint32_t i=0; i < B12_size; ++i) {
             translation_ranked[B12_sorted[i]] = rank_array[i];

--- a/misc/multithreading.cpp
+++ b/misc/multithreading.cpp
@@ -12,9 +12,9 @@
 #include <sstream>
 #include <random>
 
-#include "../integrity_validation.h"
-#include "../compression.h"
-#include "../cryptography.h"
+#include "integrity_validation.h"
+#include "compression.h"
+#include "cryptography.h"
 
 namespace multithreading
 {

--- a/misc/multithreading.h
+++ b/misc/multithreading.h
@@ -5,7 +5,6 @@
 #include <bitset>
 #include <vector>
 #include <cassert>
-#include <fstream>
 #include <thread>
 #include <sstream>
 


### PR DESCRIPTION
Przyspieszono DC3 o +-15%, dla MTF i obu wersji RLE udało się zyskać dodatkowe kilka procent, obu wersji AC nie udało się w widoczny sposób przyspieszyć, za to zostały one zrefaktoryzowane.